### PR TITLE
Пользователь может подтвердить почту после логина

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -140,7 +140,7 @@ class StatisticsSerializer(serializers.Serializer):
     )
 
 
-class UserCustomCreateSerializer(UserCreateSerializer):
+class CustomUserCreateSerializer(UserCreateSerializer):
     """Сериализатор регистрации пользователей."""
 
     class Meta:
@@ -167,7 +167,7 @@ class UserReadSerializer(UserSerializer):
         )
 
 
-class TokenCreateSerializer(TokenCreateSerializer):
+class CustomTokenCreateSerializer(TokenCreateSerializer):
     """Выдает токен. Не проверяет активирован ли пользователь."""
 
     def validate(self, attrs):

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -6,10 +6,10 @@ from rest_framework.routers import DefaultRouter
 
 from .views import (
     CardViewSet,
+    CustomTokenDestroyView,
+    CustomUserViewSet,
     GroupViewSet,
     ShopViewSet,
-    TokenDestroyView,
-    UserViewSet,
 )
 
 
@@ -17,7 +17,7 @@ app_name = 'api'
 
 router = DefaultRouter()
 
-router.register('users', UserViewSet)
+router.register('users', CustomUserViewSet)
 router.register('cards', CardViewSet)
 router.register('shops', ShopViewSet)
 router.register('groups', GroupViewSet)
@@ -36,9 +36,19 @@ schema_view = get_schema_view(
 
 
 urlpatterns = [
-    path('v1/', include(router.urls)),
-    path('v1/auth/token/logout/', TokenDestroyView.as_view(), name="logout"),
-    path('v1/auth/', include('djoser.urls.authtoken')),
+    path(
+        'v1/',
+        include(router.urls)
+    ),
+    path(
+        'v1/auth/token/logout/',
+        CustomTokenDestroyView.as_view(),
+        name='logout'
+    ),
+    path(
+        'v1/auth/',
+        include('djoser.urls.authtoken'),
+    ),
     path(
         'docs/swagger/',
         schema_view.with_ui('swagger', cache_timeout=0),

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -10,6 +10,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
 from core.models import Card, Group, Shop, UserCards
+from users.tokens import custom_token_generator
 
 from .exceptions import StatisticsError
 from .permissions import IsCardsUser, IsShopCreatorOrReadOnly
@@ -28,9 +29,10 @@ from .serializers import (
 User = get_user_model()
 
 
-class UserViewSet(UserViewSet):
+class CustomUserViewSet(UserViewSet):
     """Эндпоинт для просмотра и управления пользователями."""
 
+    token_generator = custom_token_generator
     permission_classes = (CurrentUserOrAdmin,)
 
     @action(["get", "patch"], detail=False)
@@ -42,7 +44,7 @@ class UserViewSet(UserViewSet):
             return self.partial_update(request, *args, **kwargs)
 
 
-class TokenDestroyView(TokenDestroyView):
+class CustomTokenDestroyView(TokenDestroyView):
     """Эндпоинт для выхода из учетной записи."""
 
     def post(self, request):

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -135,13 +135,14 @@ REST_FRAMEWORK = {
 DJOSER = {
     'LOGIN_FIELD': 'email',
     'SERIALIZERS': {
-        'user_create': 'api.serializers.UserCustomCreateSerializer',
+        'user_create': 'api.serializers.CustomUserCreateSerializer',
         'user': 'api.serializers.UserReadSerializer',
         'current_user': 'api.serializers.UserReadSerializer',
-        'token_create': 'api.serializers.TokenCreateSerializer',
+        'token_create': 'api.serializers.CustomTokenCreateSerializer',
     },
     'PERMISSIONS': {
         'user': ['djoser.permissions.CurrentUserOrAdmin'],
+        'activation': ['api.permissions.IsUserEmailOwner'],
     },
     'HIDE_USERS': True,
     'SEND_ACTIVATION_EMAIL': True,

--- a/backend/users/tokens.py
+++ b/backend/users/tokens.py
@@ -1,0 +1,13 @@
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+
+
+class EmailActivateTokenGenerator(PasswordResetTokenGenerator):
+    """Токен для активации почты, не портится после успешного логина."""
+
+    def _make_hash_value(self, user, timestamp):
+        email_field = user.get_email_field_name()
+        email = getattr(user, email_field, "") or ""
+        return f"{user.pk}{user.password}{timestamp}{email}"
+
+
+custom_token_generator = EmailActivateTokenGenerator()


### PR DESCRIPTION
Djoser использует стандартный токен Django для СБРОСА ПАРОЛЯ, ну и понятно, этот токен протухает после первой же успешной авторизации
Переписал генерацию этого токена именно для Djoser в части подтверждения почты, чтобы при генерации не использовалось время логина.

Добавил дополнительную проверку прав, чтобы только авторизованный пользователь мог подтвердить именно свою почту